### PR TITLE
Add output with release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,4 +140,4 @@ jobs:
           generateReleaseNotes: true
 
     outputs:
-      version: ${{ steps.version_release.outputs.VERSION }}
+      version: "${{ steps.version_release.outputs.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,20 +90,35 @@ jobs:
           echo Can't create a release on branch ${{ steps.branch.outputs.BRANCH }}
           exit 1
 
-      - name: Create new major version file
-        if: ${{ inputs.version_ini_path != '' && contains(github.event.pull_request.labels.*.name, 'release:major') }}
+      - name: Prepare release tag env var
         run: |
-          echo "${{ inputs.version_ini_prefix }}${{ steps.versions.outputs.NEW_MAJOR }}" > ${{ inputs.version_ini_path }}
+          echo "RELEASE_VERSION=undefined" >> $GITHUB_ENV
 
-      - name: Create new minor version file
-        if: ${{ inputs.version_ini_path != '' && contains(github.event.pull_request.labels.*.name, 'release:minor') }}
+      - name: See if major release
+        if: contains(github.event.pul_request.labels.*.name, 'release:major') 
         run: |
-          echo "${{ inputs.version_ini_prefix }}${{ steps.versions.outputs.NEW_MINOR }}" > ${{ inputs.version_ini_path }}
+          echo "RELEASE_VERSION=${{ steps.versions.outputs.NEW_MAJOR }}" >> $GITHUB_ENV
 
-      - name: Create new patch version file
-        if: ${{ inputs.version_ini_path != '' && contains(github.event.pull_request.labels.*.name, 'release:patch') }}
+      - name: See if minor release
+        if: contains(github.event.pull_request.labels.*.name, 'release:minor')
         run: |
-          echo "${{ inputs.version_ini_prefix }}${{ steps.versions.outputs.NEW_PATCH }}" > ${{ inputs.version_ini_path }}
+          echo "RELEASE_VERSION=${{ steps.versions.outputs.NEW_MINOR }}" >> $GITHUB_ENV
+
+      - name: See if patch release
+        if: contains(github.event.pull_request.labels.*.name, 'release:patch')
+        run: |
+          echo "RELEASE_VERSION=${{ steps.versions.outputs.NEW_PATCH }}" >> $GITHUB_ENV
+
+      - name: Exit if no release tag is found
+        if: contains(env.RELEASE_VERSION, 'undefined')
+        run: |
+          echo No release tag found - ${{ env.RELEASE_VERSION }}
+          exit 0
+
+      - name: Create new version file
+        if: inputs.version_ini_path != ''
+        run: |
+          echo "${{ inputs.version_ini_prefix }}${{ env.RELEASE_VERSION }}" > ${{ inputs.version_ini_path }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: inputs.version_ini_path != ''
@@ -111,29 +126,13 @@ jobs:
           commit_message: "chore: update version"
           branch: ${{ steps.branch.outputs.BRANCH }}
 
-      - name: Create major release
-        if: contains(github.event.pull_request.labels.*.name, 'release:major')
+      - name: Create release and tag
         uses: ncipollo/release-action@v1
         with:
-          name: 'Release ${{ steps.versions.outputs.NEW_MAJOR }}'
-          tag: 'v${{ steps.versions.outputs.NEW_MAJOR }}'
+          name: 'Release ${{ env.RELEASE_VERSION }}'
+          tag: 'v${{ env.RELEASE_VERSION }}'
           commit: ${{ steps.branch.outputs.BRANCH }}
           generateReleaseNotes: true
 
-      - name: Create minor release
-        if: contains(github.event.pull_request.labels.*.name, 'release:minor')
-        uses: ncipollo/release-action@v1
-        with:
-          name: 'Release ${{ steps.versions.outputs.NEW_MINOR }}'
-          tag: 'v${{ steps.versions.outputs.NEW_MINOR }}'
-          commit: ${{ steps.branch.outputs.BRANCH }}
-          generateReleaseNotes: true
-
-      - name: Create patch release
-        if: contains(github.event.pull_request.labels.*.name, 'release:patch')
-        uses: ncipollo/release-action@v1
-        with:
-          name: 'Release ${{ steps.versions.outputs.NEW_PATCH }}'
-          tag: 'v${{ steps.versions.outputs.NEW_PATCH }}'
-          commit: ${{ steps.branch.outputs.BRANCH }}
-          generateReleaseNotes: true
+    outputs:
+      version: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,11 @@ jobs:
           echo No release tag found - ${{ env.RELEASE_VERSION }}
           exit 0
 
+      - name: Output release version
+        shell: bash
+        run: echo "::set-output name=VERSION::$(echo $RELEASE_VERSION)"
+        id: version_release
+
       - name: Create new version file
         if: inputs.version_ini_path != ''
         run: |
@@ -135,4 +140,4 @@ jobs:
           generateReleaseNotes: true
 
     outputs:
-      version: ${{ env.RELEASE_VERSION }}
+      version: ${{ steps.version_release.outputs.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# IDE and editor specific files #
+#################################
+/nbproject
+.idea
+.project
+.buildpath
+.settings
+.vscode
+.history
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+.directory
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ jobs:
 
 ## release.yml
 
-Reusable workflow to create releases via Pull Requests merge, when PRs use labels `release:major`, `release:minor`, `release:patch`. 
+Reusable workflow to create releases via Pull Requests merge, when PRs use labels `release:major`, `release:minor`, `release:patch`.
+
+Input parameters:
+
+* `main_branch` - (mandatory) name of the branch where a new major version is allowed, in other branches major version creation will fail
+* `dist_branches` - (mandatory, array in JSON format) name of the branches where a new automatic releae will be created
+* `version_ini_path` - (optional) path of a version file in `.ini` format where the new version should be saved, this file will be pushed to the working branch
+* `version_ini_prefix` - (optional) content of version `.ini` file where the new version will be appended
 
 Usage example of caller workflow:
 
@@ -40,9 +47,23 @@ on:
     types: [closed]
 
 jobs:
-  call:
+
+  release_job:
     uses: bedita/github-workflows/.github/workflows/release.yml@main
     with:
       main_branch: 'master'
       dist_branches: '["master", "1.x"]'
+      version_ini_path: config/version.ini
+      version_ini_prefix: "[MyApp]\nversion = "
+
+  other_job:
+    runs-on: 'ubuntu-latest'
+    needs: release_job
+    steps:
+
+      - name: Debug output version
+        run: |
+          echo version var ${{ needs.release_job.outputs.version }}
 ```
+
+The newly created release version is available in the calling workflow with `${{ needs.<job_id>.outputs.version }}` - where `<job_id>` is the the job ID using this release workflow, that must be included in `needs` section in the caller job.


### PR DESCRIPTION
This PR adds a workflow output with release version to be used in the calling workflow with `${{ needs.release_job.outputs.version }}` - where `release_job` is the the job ID using the release workflow, that must be included in `needs` in the caller job. 

A check has been added: if no suitable release was found from PR labels the job ends silently without errors.