### PR TITLE
Fix release workflow, use branch main

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -9,8 +9,8 @@ jobs:
   release_job:
     uses: bedita/github-workflows/.github/workflows/release.yml@v1
     with:
-      main_branch: 'master'
-      dist_branches: '["master"]'
+      main_branch: 'main'
+      dist_branches: '["main"]'
 
   other_job:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
This fixes an error in `do-release.yml` workflow by setting `main` branch for `main_branch` and `dist_branches`