### PR TITLE
Fix: skip all jobs if PR not merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
 
   debug:
+    if: github.event.pull_request.merged
     runs-on: 'ubuntu-latest'
     steps:
       - name: Dump GitHub context


### PR DESCRIPTION
Currently only the second job is skipped in `release` workflow causing the job calling this workflow to terminate with success instead of being skipped. Other dependent jobs via `needs` are then executed instead of being skipped as well
