### PR TITLE
Update major tag

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -12,11 +12,12 @@ jobs:
       main_branch: 'main'
       dist_branches: '["main"]'
 
-  other_job:
-    runs-on: 'ubuntu-latest'
-    needs: release_job
-    steps:
-
-      - name: Debug output version
-        run: |
-          echo version var ${{ needs.release_job.outputs.version }}
+  update_major_tag:
+      runs-on: ubuntu-latest
+      needs: release_job
+      steps:
+        - uses: actions/checkout@v3
+        - uses: rickstaa/action-create-tag@v1
+          with:
+            tag: 'v${{ needs.release_job.outputs.major }}'
+            force_push_tag: true


### PR DESCRIPTION
This action job will update major release tags like `v1` or `v2` to the latest release
