### PR TITLE
Update codecov-action and upload-artifact

### DIFF
--- a/.github/workflows/php-cs-stan-unit.yml
+++ b/.github/workflows/php-cs-stan-unit.yml
@@ -164,13 +164,13 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
+        uses: 'codecov/codecov-action@v3'
         with:
-          file: './clover.xml'
+          files: './clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -97,13 +97,13 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
+        uses: 'codecov/codecov-action@v3'
         with:
-          file: './clover.xml'
+          files: './clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'


### PR DESCRIPTION
This updates `codecov/codecov-action` and `actions/upload-artifact` to `v3` to avoid deprecation warnings.

Refs:

 - https://github.com/codecov/codecov-action
 - https://github.com/actions/upload-artifact