### PR TITLE
`workflow_call.inputs.coverage_min_percentage` to set min coverage value to pass tests

### DIFF
--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -11,6 +11,11 @@ on:
         description: BEdita version to use, bedita/bedita docker release 
         required: true
         type: string
+      coverage_min_percentage:
+        description: Minimum coverage percentage to pass the test
+        required: false
+        type: number
+        default: 85
 
 jobs:
 
@@ -93,7 +98,7 @@ jobs:
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
-          percentage: '85'
+          percentage: '${{ inputs.coverage_min_percentage }}'
           filename: 'clover.xml'
 
       - name: 'Export coverage results'


### PR DESCRIPTION
This introduces `coverage_min_percentage` (default 85) to set min coverage result to pass unit tests