### PR TITLE
Update version in TOML config file 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,8 @@ jobs:
         if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.toml_conf_path != '' && inputs.toml_conf_version_key != ''}}
         uses: ciiiii/toml-editor@1.0.0
         with:
-          file: "${{ toml_conf_path }}"
-          key: "${{ toml_conf_version_key }}"
+          file: "${{ inputs.toml_conf_path }}"
+          key: "${{ inputs.toml_conf_version_key }}"
           value: "${{ env.RELEASE_VERSION }}"
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           echo major release ${{ steps.split_new.outputs._0 }}
 
-      - name: Create new version file (optional)
+      - name: Create new version file with .ini format (optional)
         if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.version_ini_path != '' }}
         run: |
           echo "${{ inputs.version_ini_prefix }}$RELEASE_VERSION" > ${{ inputs.version_ini_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,14 @@ on:
         required: false
         description: Content version.ini file (optional)
         type: string
+      toml_conf_path:
+        required: false
+        description: Path to a TOML configuration file (optional)
+        type: string
+      toml_conf_version_key:
+        required: false
+        description: Version key in a TOML configuration file (optional)
+        type: string
     outputs:
       version:
         description: The final release version
@@ -145,13 +153,21 @@ jobs:
         run: |
           echo major release ${{ steps.split_new.outputs._0 }}
 
-      - name: Create new version file
+      - name: Create new version file (optional)
         if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.version_ini_path != '' }}
         run: |
           echo "${{ inputs.version_ini_prefix }}$RELEASE_VERSION" > ${{ inputs.version_ini_path }}
 
+      - name: Update TOML configuration file (optional)
+        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.toml_conf_path != '' && inputs.toml_conf_version_key != ''}}
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "${{ toml_conf_path }}"
+          key: "${{ toml_conf_version_key }}"
+          value: "${{ env.RELEASE_VERSION }}"
+
       - uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.version_ini_path != '' }}
+        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && (inputs.version_ini_path != '' || inputs.toml_conf_path != '') }}
         with:
           commit_message: "chore: update version"
           branch: ${{ steps.branch.outputs.BRANCH }}


### PR DESCRIPTION
This PR adds TOML support to handle version info ina configuration file. 

There are two new optional input parameters:

* `toml_conf_path` - path to a TOML configuration file
* `toml_conf_version_key` - version key in a TOML configuration file

Given a TOML configuration like:

```toml
 [section.one]
 description = "lorem ipsum...." 
 version = "0.1.0"
``` 

The corresponding `toml_conf_version_key` is `section.one.version` 

