### PR TITLE
Add psalm check reusable workflow

### DIFF
--- a/.github/workflows/php-psalm.yml
+++ b/.github/workflows/php-psalm.yml
@@ -1,0 +1,50 @@
+name: 'php-psalm'
+
+on:
+  workflow_call:
+    inputs:
+      php_versions:
+        description: PHP versions to use, string formatted as JSON array 
+        required: true
+        type: string
+
+jobs:
+  psalm:
+    name: 'Check with psalm'
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        php-version: ${{ fromJSON(inputs.php_versions) }}
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php-version }}'
+          tools: 'composer:v2'
+          extensions: 'mbstring, intl'
+          coverage: 'none'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v3'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
+          restore-keys: |
+            composer-${{ github.job }}-
+            composer-
+
+      - name: 'Install dependencies with Composer'
+        run: 'composer install --prefer-dist --no-interaction'
+
+      - name: 'Run psalm'
+        run: vendor/bin/psalm

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ on:
       - 'composer.json'
 
 jobs:
-  cs:
+  psalm:
     uses: bedita/github-workflows/.github/workflows/php-psalm.yml@v1
     with:
       php_versions: '["7.4", "8.0", "8.1"]'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ jobs:
       php_versions: '["7.4", "8.0", "8.1"]'
 ```
 
+## php-psalm.yml
+
+Psalm checks on specified php versions.
+
+Usage:
+
+```yaml
+name: 'psalm'
+
+on:
+  pull_request:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/psalm.yml'
+      - 'composer.json'
+  push:
+    paths:
+      - '**/*.php'
+      - '.github/workflows/psalm.yml'
+      - 'composer.json'
+
+jobs:
+  cs:
+    uses: bedita/github-workflows/.github/workflows/php-psalm.yml@v1
+    with:
+      php_versions: '["7.4", "8.0", "8.1"]'
+```
+
 ## php-stan.yml
 
 Phpstan checks on specified php versions.


### PR DESCRIPTION
This introduces `php-psalm.yml` reusable workflow.

Example usage:
```yaml
name: 'psalm'

on:
  pull_request:
    paths:
      - '**/*.php'
      - '.github/workflows/psalm.yml'
      - 'composer.json'
  push:
    paths:
      - '**/*.php'
      - '.github/workflows/psalm.yml'
      - 'composer.json'

jobs:
  psalm:
    uses: bedita/github-workflows/.github/workflows/php-psalm.yml@v1
    with:
      php_versions: '["7.4", "8.0", "8.1"]'
```