### PR TITLE
Fix psalm to use php-version from matrix

### DIFF
--- a/.github/workflows/php-psalm.yml
+++ b/.github/workflows/php-psalm.yml
@@ -47,4 +47,4 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run psalm'
-        run: vendor/bin/psalm
+        run: vendor/bin/psalm --php-version=${{ matrix.php-version }}


### PR DESCRIPTION
This introduces a fix: use `--php-version=<version>`