### PR TITLE
fix: use toml editor fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Update TOML configuration file (optional)
         if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && inputs.toml_conf_path != '' && inputs.toml_conf_version_key != ''}}
-        uses: ciiiii/toml-editor@1.0.0
+        uses: colathro/toml-editor@1.1.1
         with:
           file: "${{ inputs.toml_conf_path }}"
           key: "${{ inputs.toml_conf_version_key }}"


### PR DESCRIPTION
This PR fixes a problem with `ciiiii/toml-editor@1.0.0` reusable workflow that is now failing to build 