### PR TITLE
codecov-action@v4 + CODECOV_TOKEN

### DIFF
--- a/.github/workflows/php-cs-stan-unit.yml
+++ b/.github/workflows/php-cs-stan-unit.yml
@@ -164,8 +164,9 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v3'
+        uses: 'codecov/codecov-action@v4'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           files: './clover.xml'
           env_vars: PHP_VERSION
 

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -102,8 +102,9 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v3'
+        uses: 'codecov/codecov-action@v4'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           files: './clover.xml'
           env_vars: PHP_VERSION
 


### PR DESCRIPTION
This updates codecov-action to version 4 (https://github.com/bedita/github-workflows/pull/30 will not be necessary afterwards): https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release

Breaking change: `secrets.CODECOV_TOKEN` is required.