### PR TITLE
Fix package.json version handling and missing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,9 @@ on:
         type: string
       package_json_version:
         required: false
-        description: Update package.json version (optional)
-        type: boolean
+        description: Update package.json version (optional, use 'true' or 'false' as a string)
+        type: string
+        default: 'false'
     outputs:
       version:
         description: The final release version
@@ -183,7 +184,7 @@ jobs:
           echo inputs.package_json_version ${{ inputs.package_json_version }}
 
       - name: Update package.json version
-        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && steps.check_files.outputs.files_exists == 'true' && inputs.package_json_version == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' && inputs.package_json_version == 'true' }}
         uses: jossef/action-set-json-field@v2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Retrieve last tag on branch
         run: |
-          echo "TAG_NAME=$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" >> $GITHUB_OUTPUT        id: last_tag
+          echo "TAG_NAME=$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" >> $GITHUB_OUTPUT
+        id: last_tag
 
       - name: Debug last tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Retrieve last tag on branch
         run: |
-          LAST_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0  | cut -c 2-) && echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_ENV
+          LAST_TAG="$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" && echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_OUPUT
         id: last_tag
 
       - name: Debug last tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Retrieve last tag on branch
         run: |
-          LAST_TAG="$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" && echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_OUPUT
+          export LAST_TAG="$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" 
+          echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_OUPUT
         id: last_tag
 
       - name: Debug last tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,7 @@ jobs:
 
       - name: Retrieve last tag on branch
         run: |
-          export LAST_TAG="$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" 
-          echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_OUPUT
-        id: last_tag
+          echo "TAG_NAME=$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" >> $GITHUB_OUTPUT        id: last_tag
 
       - name: Debug last tag
         run: |
@@ -77,7 +75,7 @@ jobs:
       - uses: jungwinter/split@v2
         id: split
         with:
-          msg: '${{ steps.last_tag.outputs.TAG_NAME }}'
+          msg: ${{ steps.last_tag.outputs.TAG_NAME != '' && steps.last_tag.outputs.TAG_NAME || '0.0.0' }}
           separator: '.'
           maxsplit: 3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           value: ${{ env.RELEASE_VERSION }}
 
       - uses: stefanzweifel/git-auto-commit-action@v5
-        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && (inputs.version_ini_path != '' || inputs.toml_conf_path != '') }}
+        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && (inputs.version_ini_path != '' || inputs.toml_conf_path != '' || inputs.package_json_version == 'true') }}
         with:
           commit_message: "chore: update version"
           branch: ${{ steps.branch.outputs.BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,11 @@ jobs:
         with:
           files: "package.json"
 
+      - name: Debug package.json vars
+        run: |
+          echo steps.check_files.outputs.files_exists ${{ steps.check_files.outputs.files_exists }}
+          echo inputs.package_json_version ${{ inputs.package_json_version }}
+
       - name: Update package.json version
         if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && steps.check_files.outputs.files_exists == 'true' && inputs.package_json_version == 'true' }}
         uses: jossef/action-set-json-field@v2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,13 @@ jobs:
 
       - name: Retrieve last tag on branch
         run: |
-          echo "TAG_NAME=$(git describe --tags --match "v*.*.*" --abbrev=0 | cut -c 2-)" >> $GITHUB_OUTPUT
+          LAST_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0  | cut -c 2-) && echo "TAG_NAME=${LAST_TAG:-0.0.0}" >> $GITHUB_ENV
         id: last_tag
 
       - name: Debug last tag
         run: |
           echo last tag ${{ steps.last_tag.outputs.TAG_NAME }}
+
       - uses: jungwinter/split@v2
         id: split
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,13 +178,8 @@ jobs:
         with:
           files: "package.json"
 
-      - name: Debug package.json vars
-        run: |
-          echo steps.check_files.outputs.files_exists ${{ steps.check_files.outputs.files_exists }}
-          echo inputs.package_json_version ${{ inputs.package_json_version }}
-
       - name: Update package.json version
-        if: ${{ steps.check_files.outputs.files_exists == 'true' && inputs.package_json_version == 'true' }}
+        if: ${{ !contains(env.RELEASE_VERSION, 'undefined') && steps.check_files.outputs.files_exists == 'true' && inputs.package_json_version == 'true' }}
         uses: jossef/action-set-json-field@v2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes two problems:

* `package_json_version` must be used as type `string` to be handled correctly with `if` conditions 
* handle  `package_json_version` true case when committing new version 
* handle missing git tags case - 0.0.0 is used as starting version in this case
