### PR TITLE
Fix php-unit and php-cs-stan-unit typo

### DIFF
--- a/.github/workflows/php-cs-stan-unit.yml
+++ b/.github/workflows/php-cs-stan-unit.yml
@@ -173,5 +173,5 @@ jobs:
       - name: 'Archive code coverage results'
         uses: 'actions/upload-artifact@v4'
         with:
-          name: 'PHP-${{ matrix.php }}-strategy-job-index-${{ strategy.job-index }}'
+          name: 'PHP-${{ matrix.php-version }}-strategy-job-index-${{ strategy.job-index }}'
           path: '${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -111,5 +111,5 @@ jobs:
       - name: 'Archive code coverage results'
         uses: 'actions/upload-artifact@v4'
         with:
-          name: 'PHP-${{ matrix.php }}-strategy-job-index-${{ strategy.job-index }}'
+          name: 'PHP-${{ matrix.php-version }}-strategy-job-index-${{ strategy.job-index }}'
           path: '${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'


### PR DESCRIPTION
This fixes a typo in setting name for `actions/upload-artifact@v4`.