### PR TITLE
Upload artifact unique name

### DIFF
--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -40,7 +40,7 @@ jobs:
         run: 'sudo apt-get install -y gettext'
 
       - name: 'Checkout current revision'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
 
       - name: 'Composer config GH token if available'
         run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
@@ -77,7 +77,7 @@ jobs:
         run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v3'
+        uses: 'actions/cache@v4'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
           key: "composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}"

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -111,5 +111,5 @@ jobs:
       - name: 'Archive code coverage results'
         uses: 'actions/upload-artifact@v4'
         with:
-          name: 'PHP-${{ matrix.php-version }}-strategy-job-index-${{ strategy.job-index }}'
-          path: '${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'
+          name: 'BEDITA-${{ inputs.bedita_version }}-PHP-${{ matrix.php-version }}-strategy-job-index-${{ strategy.job-index }}'
+          path: '${{ inputs.bedita_version }}-${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'


### PR DESCRIPTION
This fixes a problem when launching this reusable workflow on different BE versions but with the same php version.

`Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`

BE version will be part of the name of the uploaded artifact.